### PR TITLE
Fix the link to docs/CODE_OF_CONDUCT.md

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thank you for contributing your time and expertise to CDEvents. This document describes the contribution guidelines for the project.
 
-**Note:** Before you start contributing, you must read and abide by our **[Code of Conduct](./CODE-OF-CONDUCT.md)**.
+**Note:** Before you start contributing, you must read and abide by our **[Code of Conduct](./CODE_OF_CONDUCT.md)**.
 
 ## Contributing prerequisites (CLA/DCO)
 


### PR DESCRIPTION
The problem I faced: 
  When I tried to jump from docs/CONTRIBUTING.md to docs/CODE_OF_CONDUCT.md, it failed by 404.